### PR TITLE
3.5 PATH and lang fixes

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="blocks\cmanager\db" VERSION="20060905" COMMENT="XMLDB file for Moodle mod/label"
+<XMLDB PATH="blocks/cmanager/db" VERSION="20060905" COMMENT="XMLDB file for Moodle blocks/cmanager"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >

--- a/lang/en/block_cmanager.php
+++ b/lang/en/block_cmanager.php
@@ -463,7 +463,7 @@ $string['courserecorddeleted'] = 'Course record deleted';
 $string['deletecourserequest'] = 'Delete course request';
 
 
-+// GDPR Privacy API
+// GDPR Privacy API
 $string['comments'] = 'Comments';
 $string['privacy:metadata:db:block_cmanager_records:modname'] = 'The requested course full name';
 $string['privacy:metadata:db:block_cmanager_records:modcode'] = 'The requested course short name';


### PR DESCRIPTION
Hi Kyle, for some reason, the db/install.xml change didn't merge, so was causing errors on a fresh 35 install, similarly the extra char in the lang/en/block_cmanager.php file. Cheers, Karen